### PR TITLE
:focus -> :focus-visible

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -29,7 +29,7 @@ const StyledButton: React.FC<ButtonProps> = ({
     boxShadow: `1px 1px 0px 1px ${grey} inset, 
                 -1px -1px 0px 1px ${black} inset`,
     outline: 'none',
-    ':focus': {
+    ':focus-visible': {
       borderColor: 'blue',
     },
     ':active': {

--- a/components/filter.tsx
+++ b/components/filter.tsx
@@ -56,7 +56,7 @@ const Filter: React.FC<FilterProps> = ({
               p: 1,
               pb: 0,
               color: 'blue',
-              ':focus': {
+              ':focus-visible': {
                 boxShadow:
                   'inset 0 3px 0 -2px blue, inset -3px 0 0 -2px blue, inset 3px 0 0 -2px blue',
                 outline: 'none',

--- a/components/input.tsx
+++ b/components/input.tsx
@@ -36,7 +36,7 @@ const TextInput: React.FC<TextInputProps> = ({
             px: 3,
             width: '100%',
             outline: 'none',
-            ':focus': {
+            ':focus-visible': {
               '::placeholder': { color: 'mediumGray' },
               borderColor: 'blue',
             },

--- a/components/link.tsx
+++ b/components/link.tsx
@@ -24,7 +24,7 @@ const StyledLink: React.FC<LinkProps> = ({
     border: '1px solid',
     borderColor: 'transparent',
     outline: 'none',
-    ':focus': {
+    ':focus-visible': {
       borderColor: 'blue',
     },
     padding: 0,

--- a/components/search.tsx
+++ b/components/search.tsx
@@ -33,7 +33,7 @@ const Search: React.FC<SearchProps> = ({
           width: '100%',
           outline: 'none',
           '::placeholder': { color: 'black' },
-          ':focus': {
+          ':focus-visible': {
             '::placeholder': { color: 'mediumGray' },
             borderColor: 'blue',
           },

--- a/components/select.tsx
+++ b/components/select.tsx
@@ -47,7 +47,7 @@ const Select: React.FC<SelectProps> = ({
           background: 'backgroundGray',
           px: 3,
           outline: 'none',
-          ':focus': {
+          ':focus-visible': {
             borderColor: 'blue',
           },
         }}


### PR DESCRIPTION
Tiny tweak, but I realized the focus styles were showing up whenever interacting with an element (e.g., the beautiful `Button` press interaction). This change updates those styles to just appear on [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible), which is based on user agent information (i.e. so the focus state mainly shows up when using accessibility features like keyboard tabbing).