### PR TITLE
Scroll panelled page conent to top when path changes

### DIFF
--- a/components/layouts/paneled-page.tsx
+++ b/components/layouts/paneled-page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { Box, Flex } from 'theme-ui'
+import { usePathname } from 'next/navigation'
 
 import Row from '../row'
 import Column from '../column'
@@ -17,6 +18,15 @@ const PaneledPage: React.FC<{
   leftCorner?: React.ReactNode
   rightCorner?: React.ReactNode
 }> = ({ children, sidebar, metadata, title, leftCorner, rightCorner }) => {
+  const contentRef = useRef<HTMLDivElement>(null)
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (contentRef.current) {
+      contentRef.current.scrollIntoView()
+    }
+  }, [pathname])
+
   return (
     <Row sx={{ height: `calc(100vh - ${HEADER_HEIGHT}px)` }}>
       <Column
@@ -37,6 +47,7 @@ const PaneledPage: React.FC<{
         }}
       >
         <Box
+          ref={contentRef}
           sx={{
             width: '100%',
             background: 'primary',


### PR DESCRIPTION
This makes it so that when going to the next/prev step in the submit process, the content is scrolled to the top instead of maintaining the prior step's scroll position. 