### PR TITLE
data page (render abstract)

### DIFF
--- a/app/preprint/[id]/preprint-viewer.tsx
+++ b/app/preprint/[id]/preprint-viewer.tsx
@@ -75,9 +75,13 @@ const PreprintViewer = ({
           {preprint.doi}
         </StyledLink>
       )}
-      <Box sx={{ variant: 'text.mono', mt: 3, mb: 4 }}>
+      <Box sx={{ variant: 'text.mono', mt: 3, mb: 7 }}>
         {authorList(preprint.authors)}
       </Box>
+      <Box sx={{ variant: 'text.monoCaps', fontSize: [3, 3, 3, 4], mb: 4 }}>
+        Abstract
+      </Box>
+      <Box sx={{ variant: 'text.body', mb: 7 }}>{preprint.abstract}</Box>
       {hasArticle && (
         <div ref={containerRef} style={{ width: '100%' }}>
           <Document


### PR DESCRIPTION
This adds abstract rendering for all preprint viewing pages, which will fill out our data only view as well. 