### PR TITLE
handle missing zenodo entry more gracefully

### DIFF
--- a/actions/zenodo.ts
+++ b/actions/zenodo.ts
@@ -41,6 +41,7 @@ export async function fetchDataDeposition(url: string): Promise<Deposition> {
   const result = await res.json()
   return result
 }
+
 export async function updateDataDeposition(
   url: string,
   params: Partial<Deposition>,
@@ -85,13 +86,15 @@ export async function deleteZenodoEntity(url: string): Promise<true> {
     },
   })
 
-  if (res.status !== 204) {
-    throw new Error(
-      `Status ${res.status}: Unable to delete deposition. ${res.statusText}`,
-    )
+  if (res.status === 204 || res.status === 404) {
+    // 204: Successful deletion
+    // 404: Entity not found (consider it already deleted)
+    return true
   }
 
-  return true
+  throw new Error(
+    `Status ${res.status}: Unable to delete deposition. ${res.statusText}`,
+  )
 }
 
 export async function createDataDepositionFile(

--- a/app/submit/(authed)/overview/data-file-display.tsx
+++ b/app/submit/(authed)/overview/data-file-display.tsx
@@ -16,10 +16,16 @@ const DataFileDisplay: React.FC<Props> = ({ file: fileProp }) => {
 
   useEffect(() => {
     if (fileProp?.url) {
-      fetchDataDeposition(fileProp.url).then((deposition) => {
-        setDeposition(deposition)
-        setLoading(false)
-      })
+      fetchDataDeposition(fileProp.url)
+        .then((deposition) => {
+          setDeposition(deposition)
+          setLoading(false)
+        })
+        .catch((error) => {
+          console.error('Error fetching deposition:', error)
+          setLoading(false)
+          setDeposition(null)
+        })
     }
   }, [fileProp])
 

--- a/app/submit/(authed)/overview/data-file-input.tsx
+++ b/app/submit/(authed)/overview/data-file-input.tsx
@@ -36,6 +36,7 @@ const DataFileInput: React.FC<Props> = ({
         .catch(() => {
           // TODO: remove from supplementary files
           setFileProp(null)
+          setLoading(false)
         })
     } else {
       setDeposition(null)


### PR DESCRIPTION
This was likley just an issue because we can't currently update the supplementary files on janeway, but I got stuck in a little loop where I couldn't get to a working submission after deleting a data only upload. I just added a couple extra things here to keep the form working in cases where the deposition file isn't found on zenodo. 