### PR TITLE
fixes for submit issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@ AUTH_CLIENT_ID=
 AUTH_CLIENT_SECRET=
 NEXTAUTH_SECRET=
 NEXTAUTH_URL=http://localhost:3000
-ZENODO_URL=https://sandbox.zenodo.org
+NEXT_PUBLIC_ZENODO_URL=https://sandbox.zenodo.org
 ZENODO_ACCESS_TOKEN=

--- a/actions/zenodo.ts
+++ b/actions/zenodo.ts
@@ -3,21 +3,27 @@
 import { Deposition, DepositionFile } from '../types/zenodo'
 
 export async function createDataDeposition(): Promise<Deposition> {
-  const res = await fetch(process.env.ZENODO_URL + '/api/deposit/depositions', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${process.env.ZENODO_ACCESS_TOKEN}`,
-      'Content-Type': 'application/json',
+  const res = await fetch(
+    process.env.NEXT_PUBLIC_ZENODO_URL + '/api/deposit/depositions',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.ZENODO_ACCESS_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ metadata: { upload_type: 'dataset' } }),
     },
-    body: JSON.stringify({ metadata: { upload_type: 'dataset' } }),
-  })
+  )
 
   const result = await res.json()
   return result
 }
 
 export async function fetchDataDeposition(url: string): Promise<Deposition> {
-  if (process.env.ZENODO_URL && !url.startsWith(process.env.ZENODO_URL)) {
+  if (
+    process.env.NEXT_PUBLIC_ZENODO_URL &&
+    !url.startsWith(process.env.NEXT_PUBLIC_ZENODO_URL)
+  ) {
     throw new Error(`Invalid data URL: ${url}`)
   }
   const res = await fetch(url, {
@@ -40,7 +46,10 @@ export async function updateDataDeposition(
   url: string,
   params: Partial<Deposition>,
 ): Promise<Deposition> {
-  if (process.env.ZENODO_URL && !url.startsWith(process.env.ZENODO_URL)) {
+  if (
+    process.env.NEXT_PUBLIC_ZENODO_URL &&
+    !url.startsWith(process.env.NEXT_PUBLIC_ZENODO_URL)
+  ) {
     throw new Error(`Invalid data URL: ${url}`)
   }
   const res = await fetch(url, {
@@ -63,7 +72,10 @@ export async function updateDataDeposition(
 }
 
 export async function deleteZenodoEntity(url: string): Promise<true> {
-  if (process.env.ZENODO_URL && !url.startsWith(process.env.ZENODO_URL)) {
+  if (
+    process.env.NEXT_PUBLIC_ZENODO_URL &&
+    !url.startsWith(process.env.NEXT_PUBLIC_ZENODO_URL)
+  ) {
     throw new Error(`Invalid data URL: ${url}`)
   }
 
@@ -90,7 +102,8 @@ export async function createDataDepositionFile(
   formData: FormData,
 ): Promise<DepositionFile> {
   const res = await fetch(
-    process.env.ZENODO_URL + `/api/deposit/depositions/${deposition}/files`,
+    process.env.NEXT_PUBLIC_ZENODO_URL +
+      `/api/deposit/depositions/${deposition}/files`,
     {
       method: 'POST',
       headers: {
@@ -112,7 +125,10 @@ export async function createDataDepositionFile(
 export async function createDataDepositionVersion(
   url: string,
 ): Promise<Deposition> {
-  if (process.env.ZENODO_URL && !url.startsWith(process.env.ZENODO_URL)) {
+  if (
+    process.env.NEXT_PUBLIC_ZENODO_URL &&
+    !url.startsWith(process.env.NEXT_PUBLIC_ZENODO_URL)
+  ) {
     throw new Error(`Invalid data URL: ${url}`)
   }
   const res = await fetch(url, {

--- a/app/preprint/[id]/metadata-view.tsx
+++ b/app/preprint/[id]/metadata-view.tsx
@@ -7,7 +7,7 @@ import type { Preprint, Funder } from '../../../types/preprint'
 import type { Deposition } from '../../../types/zenodo'
 
 const getDataDownload = (deposition: Deposition) => {
-  return `${process.env.ZENODO_URL}/records/${deposition.id}/files/${deposition.files[0].filename}?download=1`
+  return `${process.env.NEXT_PUBLIC_ZENODO_URL}/records/${deposition.id}/files/${deposition.files[0].filename}?download=1`
 }
 
 const MetadataView: React.FC<{


### PR DESCRIPTION
The main issue was the name of the zenodo env variable - changed here from `NEXT_PUBLIC_ZENODO_URL` to `ZENODO_URL` which matches what we have in env vars on vercel. (I'll clean up my testing one up there in a sec). The mismatch is why this was only showing up in prod!

Also fixed an issue where we showed a `NEXT STEP` nav on the confirmation page which bypassed the submit process. 

also added some loading state for the submit process and fixed an import name. 