### PR TITLE
submission type aware success message

### DIFF
--- a/app/submit/(authed)/success/page.tsx
+++ b/app/submit/(authed)/success/page.tsx
@@ -2,12 +2,20 @@
 
 import { Box } from 'theme-ui'
 
-import { Form, Link } from '../../../components'
+import { Form, Link } from '../../../../components'
 import { useEffect, useRef, useState } from 'react'
+import { usePreprint } from '../preprint-context'
+import { getAdditionalField } from '../../../../utils/data'
 
 const Success = () => {
   const [decoration, setDecoration] = useState('₊˚⊹⋆')
   const timeout = useRef<NodeJS.Timeout | null>(null)
+  const { preprint } = usePreprint()
+  const type = getAdditionalField(preprint, 'Submission type')
+  const printedType = (
+    type === 'Both' ? 'article and data were' : type + ' was'
+  ).toLowerCase()
+
   useEffect(() => {
     const animate = () => {
       timeout.current = setTimeout(() => {
@@ -27,7 +35,7 @@ const Success = () => {
   return (
     <Form>
       <Box sx={{ variant: 'text.monoCaps' }}>
-        {decoration} Your paper was successfully submitted!{' '}
+        {decoration} Your {printedType} successfully submitted!{' '}
         {decoration.split('').reverse().join('')}
       </Box>
 


### PR DESCRIPTION
quick one to add the correct info to the submit message based on submission type. Moved the success page under `(authed)` to get access to the preprint context. 