### PR TITLE
Trigger path revalidation in mutations

### DIFF
--- a/actions/preprint.ts
+++ b/actions/preprint.ts
@@ -2,7 +2,7 @@
 
 import { headers, cookies } from 'next/headers'
 import { getToken } from 'next-auth/jwt'
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import {
   Author,
   AuthorParams,
@@ -55,7 +55,7 @@ export async function updatePreprint(
 
   const updatedPreprint = res.json()
 
-  revalidatePath('/submit')
+  revalidateTag('submit')
   return updatedPreprint
 }
 
@@ -108,7 +108,7 @@ export async function createPreprint(): Promise<Preprint> {
   }
 
   const preprint = res.json()
-  revalidatePath('/submit')
+  revalidateTag('submit')
 
   return preprint
 }
@@ -172,7 +172,7 @@ export async function createPreprintFile(
 
   const result = res.json()
 
-  revalidatePath('/submit')
+  revalidateTag('submit')
   return result
 }
 export async function fetchPreprintFile(pk: number): Promise<PreprintFile> {
@@ -206,7 +206,7 @@ export async function deletePreprintFile(pk: number): Promise<true> {
     )
   }
 
-  revalidatePath('/submit')
+  revalidateTag('submit')
   return true
 }
 

--- a/app/submit/(authed)/layout.tsx
+++ b/app/submit/(authed)/layout.tsx
@@ -15,10 +15,12 @@ const SubmissionOverview: React.FC<Props> = async ({ children }) => {
     fetchWithToken(
       headers(),
       'https://carbonplan.endurance.janeway.systems/carbonplan/api/user_preprints/?stage=preprint_unsubmitted',
+      { next: { tags: ['submit'] } },
     ),
     fetchWithToken(
       headers(),
       'https://carbonplan.endurance.janeway.systems/carbonplan/api/preprint_files/',
+      { next: { tags: ['submit'] } },
     ),
   ])
 


### PR DESCRIPTION
This PR triggers revalidation of the `/submit` page requests (preprints and preprint files fetching) on mutation actions:
- `updatePreprint()`
- `createPreprint()`
- `createPreprintFile()`
- `deletePreprintFile()`

I also updated the OAuth client settings so that you can use this [preview link](https://cdrxiv-org-git-katamartin-cache-busting-carbonplan.vercel.app/) to authenticate with Janeway + go through the submission process. Locally, the `revalidatePath` calls trigger a flash of the page w/o the fonts, but this does not affect the app on Vercel.