### PR TITLE
Prevent preprint resubmission

### DIFF
--- a/app/submit/(authed)/confirm/page.tsx
+++ b/app/submit/(authed)/confirm/page.tsx
@@ -153,7 +153,7 @@ const SubmissionConfirmation = () => {
           user: preprint.owner,
           submission_type: submissionType,
         })
-        router.push('/submit/success')
+        router.push(`/submit/success?type=${submissionType}`)
       })
       .catch((err) => {
         track('preprint_submitted_error', {

--- a/app/submit/(authed)/success/page.tsx
+++ b/app/submit/(authed)/success/page.tsx
@@ -1,17 +1,16 @@
 'use client'
 
 import { Box } from 'theme-ui'
-
+import { useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
+
 import { Form, Link } from '../../../../components'
-import { getAdditionalField } from '../../../../utils/data'
-import { usePreprint } from '../../preprint-context'
 
 const Success = () => {
   const [decoration, setDecoration] = useState('₊˚⊹⋆')
+  const searchParams = useSearchParams()
   const timeout = useRef<NodeJS.Timeout | null>(null)
-  const { preprint } = usePreprint()
-  const type = getAdditionalField(preprint, 'Submission type')
+  const type = searchParams.get('type') ?? 'work'
   const printedType = (
     type === 'Both' ? 'article and data were' : type + ' was'
   ).toLowerCase()

--- a/app/submit/preprint-context.tsx
+++ b/app/submit/preprint-context.tsx
@@ -58,6 +58,15 @@ export const PreprintProvider: React.FC<ProviderProps> = ({
     }
   }, [newlyCreated, track])
 
+  useEffect(() => {
+    if (!preprints[0]) {
+      return
+    }
+
+    // Update reference to new preprint if old preprint has been submitted
+    setValue((prev) => (prev?.pk === preprints[0].pk ? prev : preprints[0]))
+  }, [preprints[0]?.pk])
+
   return (
     <PreprintContext.Provider
       value={{ preprint: value, setPreprint: setValue, files, setFiles }}


### PR DESCRIPTION
This PR makes some small improvements to submission:
- Ensures that the `PreprintProvider` component updates its `value` when the submission `Layout` detects and creates a new preprint (triggered by previous preprint submission).
  - This means that the preprint context value on `/submit/success` will no longer be the just-submitted preprint. Instead of relying on the context value, we are now passing the submission type through query parameters.
  - Addresses https://linear.app/carbonplan/issue/PRO-46/user-can-update-submission-if-they-dont-refresh
- Random fix: improve `SelectPreprint` view (edge case, should only be triggered by testing) by nesting within `PaneledPage`