### PR TITLE
Render externally hosted data

### DIFF
--- a/app/preprint/[id]/preprint-metadata.tsx
+++ b/app/preprint/[id]/preprint-metadata.tsx
@@ -183,11 +183,20 @@ const PreprintMetadata: React.FC<{
       </Flex>
 
       {externalData && (
-        <Field label='External data'>
-          <Link href={externalData.url} sx={{ variant: 'text.mono' }}>
-            {externalData.label}
-          </Link>
-        </Field>
+        <Box>
+          <Field label='External data'>
+            <Link href={externalData.url} sx={{ variant: 'text.mono' }}>
+              {externalData.label}
+            </Link>
+          </Field>
+          <ErrorOrTrack
+            mt={2}
+            hasError={hasData}
+            preview={preview}
+            pk={preprint.pk}
+            errorMessage={'External data present on a data submission.'}
+          />
+        </Box>
       )}
 
       <Field label='Funders'>


### PR DESCRIPTION
See https://cdrxiv-org-git-katamartin-external-data-carbonplan.vercel.app/preprint/242 as an example of rendering pattern