### PR TITLE
Fix a few cases where client components import actions directly

### DIFF
--- a/actions/index.js
+++ b/actions/index.js
@@ -2,6 +2,7 @@ import { throwActionErrors } from './client-utils'
 import {
   registerAccount as registerAccountBase,
   updateAccount as updateAccountBase,
+  activateAccount as activateAccountBase,
 } from './account'
 import {
   createPreprintFile as createPreprintFileBase,
@@ -25,6 +26,7 @@ import { verify as verifyBase } from './hcaptcha'
 
 export const registerAccount = throwActionErrors(registerAccountBase)
 export const updateAccount = throwActionErrors(updateAccountBase)
+export const activateAccount = throwActionErrors(activateAccountBase)
 
 export const createPreprintFile = throwActionErrors(createPreprintFileBase)
 export const createVersionQueue = throwActionErrors(createVersionQueueBase)

--- a/app/(userSection)/register/activate/[code]/agreement-activation.tsx
+++ b/app/(userSection)/register/activate/[code]/agreement-activation.tsx
@@ -5,7 +5,7 @@ import { useCallback, useState } from 'react'
 
 import Agreement from '../../agreement'
 import { Button, Field, Form, Link } from '../../../../../components'
-import { activateAccount } from '../../../../../actions/account'
+import { activateAccount } from '../../../../../actions'
 
 const AgreementActivation = ({
   user,

--- a/app/preprint/[id]/preprint-viewer.tsx
+++ b/app/preprint/[id]/preprint-viewer.tsx
@@ -18,7 +18,7 @@ import Loading from '../../../components/loading'
 import useTracking from '../../../hooks/use-tracking'
 import { AuthorsList } from '../../../components'
 import { Deposition } from '../../../types/zenodo'
-import { fetchDataDeposition } from '../../../actions/zenodo'
+import { fetchDataDeposition } from '../../../actions'
 import ErrorOrTrack from './error-or-track'
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`


### PR DESCRIPTION
Oops! Probably a good nudge to revisit the idea of a lint rule, or at least prefixing raw actions with underscores.