### PR TITLE
Always handle home.html route

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -22,11 +22,13 @@ export const middleware = (
   request: NextRequestWithAuth,
   event: NextFetchEvent,
 ) => {
+  if (request.nextUrl.pathname === '/home.html') {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
   if (isFullSiteEnabled()) {
     if (AUTHED_ROUTES.includes(request.nextUrl.pathname)) {
       return withAuthMiddleware(request, event)
-    } else if (request.nextUrl.pathname === '/home.html') {
-      return NextResponse.redirect(new URL('/', request.url))
     } else {
       return NextResponse.next()
     }


### PR DESCRIPTION
This PR updates middleware so that `home.html` route is always handled, even if full site is not enabled (i.e. https://www.cdrxiv.org/home.html)