### PR TITLE
Try revalidating on preprint page

### DIFF
--- a/app/preprint/[id]/page.tsx
+++ b/app/preprint/[id]/page.tsx
@@ -24,7 +24,7 @@ if (typeof Promise.withResolvers !== 'function') {
 const getPreprint = async (id: string) => {
   const res = await fetchWithAlerting(
     `${process.env.NEXT_PUBLIC_JANEWAY_URL}/api/published_preprints/${id}`,
-    {},
+    { next: { revalidate: 180 } },
     [200, 404],
   )
   if (!res.ok) {


### PR DESCRIPTION
This PR sets up revalidation on the preprint page to match landing page behavior. Previously, we ran into situations where the landing page content could be out-of-sync with the preprint page content (e.g., when a revision was published).