### PR TITLE
Metadata panel updates

### DIFF
--- a/app/preprint/[id]/preprint-metadata.tsx
+++ b/app/preprint/[id]/preprint-metadata.tsx
@@ -262,7 +262,7 @@ const PreprintMetadata: React.FC<{
 
       {hasConflictOfInterest && (
         <Field label='Conflict of interest'>
-          <Box sx={{ variant: 'text.body', fontSize: 2 }}>
+          <Box sx={{ variant: 'text.body', fontSize: [1, 1, 1, 2] }}>
             {conflictOfInterest}
           </Box>
         </Field>


### PR DESCRIPTION
This PR partially fixes an issue where the wrong date is shown on the preprint page because there is a mismatch of the date in the version history and the published date on the preprint.

It also drops the size of the conflict of interest statement font. 