### PR TITLE
Abstract whitespace formatting

### DIFF
--- a/app/preprint/[id]/preprint-viewer.tsx
+++ b/app/preprint/[id]/preprint-viewer.tsx
@@ -177,7 +177,7 @@ const PreprintViewer = ({
       <Box sx={{ variant: 'text.monoCaps', fontSize: [3, 3, 3, 4], mb: 4 }}>
         Abstract
       </Box>
-      <Box as='pre' sx={{ variant: 'text.body', mb: 9 }}>
+      <Box sx={{ variant: 'text.body', whiteSpace: 'pre-wrap', mb: 9 }}>
         {preprint.abstract}
       </Box>
       {hasArticle && preprint.versions.length > 0 && (

--- a/app/submit/(authed)/confirm/page.tsx
+++ b/app/submit/(authed)/confirm/page.tsx
@@ -255,7 +255,7 @@ const SubmissionConfirmation = () => {
             <Box sx={{ variant: 'text.body' }}>
               {info.data.title || 'No title'}
             </Box>
-            <Box as='pre' sx={{ variant: 'text.mono' }}>
+            <Box sx={{ whiteSpace: 'pre-wrap' }}>
               {info.data.abstract || 'No abstract'}
             </Box>
             <Flex sx={{ gap: 2, flexWrap: 'wrap' }}>


### PR DESCRIPTION
Use `white-space: pre-wrap` to respect `\n` that are captured by the abstract `textarea`.