### PR TITLE
Fix `Card` `title` clipping

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -171,13 +171,18 @@ const Card: React.FC<CardProps> = ({
                 id={`card-title-${title}`}
                 sx={{
                   variant: 'styles.h3',
-                  mb: [3, 3, 3, 4],
                   pr: [36, 36, 48, 48],
                   color,
                   display: '-webkit-box',
                   WebkitLineClamp: 4,
                   WebkitBoxOrient: 'vertical',
                   overflow: 'hidden',
+                  pb: '0.14em',
+                  mb: (theme) =>
+                    [3, 3, 3, 4].map(
+                      (space) =>
+                        `calc(${theme.space ? theme.space[space] : 0}px - 0.14em)`,
+                    ),
                 }}
               >
                 {title}


### PR DESCRIPTION
This PR adds a small amount of padding (and negative margin) to the `Card` `title` to prevent clipping descenders of letters. See related Stack Overflow [issue](https://stackoverflow.com/questions/63977541/descenders-of-letters-get-cropped-out-when-using-webkit-line-clamp-with-reduced) for more context.

**Before**
![CleanShot 2025-01-23 at 14 41 57@2x](https://github.com/user-attachments/assets/6f660927-9c00-4cc8-8154-b490bb9e144c)
**After**
![CleanShot 2025-01-23 at 14 41 36@2x](https://github.com/user-attachments/assets/0813647a-c070-4a24-b1f2-145741472be9)
