### PR TITLE
Bump down descender spacing slightly

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -177,11 +177,11 @@ const Card: React.FC<CardProps> = ({
                   WebkitLineClamp: 4,
                   WebkitBoxOrient: 'vertical',
                   overflow: 'hidden',
-                  pb: '0.14em',
+                  pb: '0.05em',
                   mb: (theme) =>
                     [3, 3, 3, 4].map(
                       (space) =>
-                        `calc(${theme.space ? theme.space[space] : 0}px - 0.14em)`,
+                        `calc(${theme.space ? theme.space[space] : 0}px - 0.05em)`,
                     ),
                 }}
               >


### PR DESCRIPTION
Followup to https://github.com/cdrxiv/cdrxiv.org/pull/143 to ensure that top line of truncated text is not shown

### Before
![CleanShot 2025-01-30 at 13 08 37@2x](https://github.com/user-attachments/assets/ba547b9d-bf5b-44fe-a09f-7252c450c4dd)

### After
![CleanShot 2025-01-30 at 13 08 28@2x](https://github.com/user-attachments/assets/11ba45da-2486-45ec-997e-0d985890c4e6)
