### PR TITLE
Fix clipping of title text

### DIFF
--- a/app/landing-page.tsx
+++ b/app/landing-page.tsx
@@ -16,7 +16,12 @@ const LandingPage: React.FC<LandingPageProps> = ({ children }) => {
         <Column start={1} width={[6, 8, 3, 3]}>
           <Box
             as='h1'
-            sx={{ variant: 'styles.h1', mt: [2, 2, 0, 0], mb: [6, 6, 4, 4] }}
+            sx={{
+              variant: 'styles.h1',
+              mt: [2, 2, 0, 0],
+              mb: [6, 6, 4, 4],
+              pt: [0, 0, '2px', 0], // fix for clipping of text.
+            }}
           >
             Preprints&nbsp;and <br />
             Data&nbsp;for&nbsp;Carbon <br />


### PR DESCRIPTION
This was the simplest solution I could come up with to solve this. There's a lot going on with the header positioning, so there's likely a cleaner way to sort out this issue, but I wasn't finding it after a bit of trying!

This happens at our 3rd breakpoint. 

before:
![CleanShot 2025-04-10 at 14 27 55](https://github.com/user-attachments/assets/f8d71f51-38da-4304-9194-ed2d9609ae70)

after:
![CleanShot 2025-04-10 at 14 28 17](https://github.com/user-attachments/assets/9e9de606-2850-4ed8-b656-7966f4ee8dad)
