### PR TITLE
Rely on Zenodo deposition DOI exclusively for data-only submissions

### DIFF
--- a/app/preprint/[id]/preprint-viewer.tsx
+++ b/app/preprint/[id]/preprint-viewer.tsx
@@ -173,6 +173,13 @@ const PreprintViewer = ({
         {(isDepositionLoading || deposition) && (
           <DOIDisplay label='Dataset DOI' doi={deposition?.doi_url} />
         )}
+
+        <ErrorOrTrack
+          hasError={hasData && !isDepositionLoading && !deposition?.doi_url}
+          preview={preview}
+          pk={preprint.pk}
+          errorMessage={'No dataset identifier found for data-only submission.'}
+        />
       </Flex>
       <Box sx={{ variant: 'text.mono', mt: 3, mb: 7 }}>
         <AuthorsList authors={preprint.authors} orcidLinks />

--- a/app/preprint/[id]/preprint-viewer.tsx
+++ b/app/preprint/[id]/preprint-viewer.tsx
@@ -53,7 +53,7 @@ const PreprintViewer = ({
   const [isDepositionLoading, setIsDepositionLoading] = useState<boolean>(
     hasData && !!dataUrl,
   )
-  const [isDoiLoading, setIsDoiLoading] = useState<boolean>(true)
+  const [isDoiLoading, setIsDoiLoading] = useState<boolean>(hasArticle)
 
   useEffect(() => {
     const fetchDoi = async () => {
@@ -68,8 +68,10 @@ const PreprintViewer = ({
       }
     }
 
-    fetchDoi()
-  }, [preprint.pk])
+    if (hasArticle) {
+      fetchDoi()
+    }
+  }, [hasArticle, preprint.pk])
 
   useEffect(() => {
     const fetchDeposition = async () => {
@@ -158,7 +160,7 @@ const PreprintViewer = ({
           <DOIDisplay label='DOI' doi={preprintDoi} />
         )}
         <ErrorOrTrack
-          hasError={!isDoiLoading && !preprintDoi}
+          hasError={hasArticle && !isDoiLoading && !preprintDoi}
           preview={preview}
           pk={preprint.pk}
           errorMessage={


### PR DESCRIPTION
See `/preview/322` for example submission