### PR TITLE
Add new data licenses

### DIFF
--- a/app/about/faq/faq-content.tsx
+++ b/app/about/faq/faq-content.tsx
@@ -85,7 +85,7 @@ If you see a confirmation page with account information, this means that your la
   {
     question: 'What license options are available for my CDRXIV submission?',
     answer:
-      'You can select your preferred license from a list on the submission page. Articles and data can be licensed differently, even if they’re part of the same submission. The article license options are: CC-BY, CC-BY-NC, and All Rights Reserved. The data license options are CC-BY and CC-BY-NC.',
+      'You can select your preferred license from a list on the submission page. Articles and data can be licensed differently, even if they’re part of the same submission. The article license options are: CC BY, CC BY-NC, and All Rights Reserved. The data license options are CC BY, CC BY-NC, CC BY-SA, and CC BY-NC-SA.',
     tags: ['submissions', 'submissions-article', 'submissions-data'],
     slug: 'license-options',
   },

--- a/app/preprint/[id]/preprint-metadata.tsx
+++ b/app/preprint/[id]/preprint-metadata.tsx
@@ -204,7 +204,7 @@ const PreprintMetadata: React.FC<{
       </Field>
 
       <Field label='License'>
-        <Flex sx={{ gap: 2, variant: 'text.mono' }}>
+        <Flex sx={{ gap: 2, flexWrap: 'wrap', variant: 'text.mono' }}>
           {articleLicenseInfo?.url ? (
             <Link href={articleLicenseInfo.url} sx={{ variant: 'text.mono' }}>
               {articleLicenseInfo.name}
@@ -228,7 +228,7 @@ const PreprintMetadata: React.FC<{
         {submissionType === 'Both' && (
           <>
             {dataLicenseInfo && (
-              <Flex sx={{ gap: 2, variant: 'text.mono' }}>
+              <Flex sx={{ gap: 2, flexWrap: 'wrap', variant: 'text.mono' }}>
                 <Link href={dataLicenseInfo.url} sx={{ variant: 'text.mono' }}>
                   {dataLicenseInfo.name}
                 </Link>

--- a/app/preprint/[id]/preprint-metadata.tsx
+++ b/app/preprint/[id]/preprint-metadata.tsx
@@ -204,35 +204,42 @@ const PreprintMetadata: React.FC<{
       </Field>
 
       <Field label='License'>
-        <Flex sx={{ gap: 2, flexWrap: 'wrap', variant: 'text.mono' }}>
-          {articleLicenseInfo?.url ? (
-            <Link href={articleLicenseInfo.url} sx={{ variant: 'text.mono' }}>
-              {articleLicenseInfo.name}
-            </Link>
-          ) : (
-            <Box>{articleLicenseInfo?.name}</Box>
-          )}
-          {submissionType === 'Both' ? '(Article)' : null}
-        </Flex>
-        <ErrorOrTrack
-          mt={2}
-          hasError={!articleLicenseInfo}
-          preview={preview}
-          pk={preprint.pk}
-          errorMessage={
-            preprint.license
-              ? `No license information found for pk=${preprint.license.pk}.`
-              : 'No license provided.'
-          }
-        />
-        {submissionType === 'Both' && (
+        {submissionType !== 'Data' && (
+          <>
+            <Flex sx={{ gap: 2, flexWrap: 'wrap', variant: 'text.mono' }}>
+              {articleLicenseInfo?.url ? (
+                <Link
+                  href={articleLicenseInfo.url}
+                  sx={{ variant: 'text.mono' }}
+                >
+                  {articleLicenseInfo.name}
+                </Link>
+              ) : (
+                <Box>{articleLicenseInfo?.name}</Box>
+              )}
+              {submissionType === 'Both' ? '(Article)' : null}
+            </Flex>
+            <ErrorOrTrack
+              mt={2}
+              hasError={!articleLicenseInfo}
+              preview={preview}
+              pk={preprint.pk}
+              errorMessage={
+                preprint.license
+                  ? `No license information found for pk=${preprint.license.pk}.`
+                  : 'No license provided.'
+              }
+            />
+          </>
+        )}
+        {submissionType !== 'Article' && (
           <>
             {dataLicenseInfo && (
               <Flex sx={{ gap: 2, flexWrap: 'wrap', variant: 'text.mono' }}>
                 <Link href={dataLicenseInfo.url} sx={{ variant: 'text.mono' }}>
                   {dataLicenseInfo.name}
                 </Link>
-                (Data)
+                {submissionType === 'Both' ? '(Data)' : null}
               </Flex>
             )}
             <ErrorOrTrack

--- a/app/submit/(authed)/info/licenses.tsx
+++ b/app/submit/(authed)/info/licenses.tsx
@@ -1,6 +1,5 @@
 import { Column, Row, Select } from '../../../../components'
 import { getArticleLicense } from '../../../../utils/data'
-import { LICENSE_MAPPING } from '../../constants'
 
 type Props = {
   license: number
@@ -72,7 +71,6 @@ const ArticleLicense = ({
 const DataLicense = ({
   dataLicense,
   setDataLicense,
-  setLicense,
 }: {
   dataLicense: string
   setDataLicense: (value: string) => void
@@ -82,11 +80,6 @@ const DataLicense = ({
     value={dataLicense}
     onChange={(e) => {
       setDataLicense(e.target.value)
-      if (e.target.value && setLicense) {
-        setLicense(
-          LICENSE_MAPPING[e.target.value as 'cc-by-4.0' | 'cc-by-nc-4.0'],
-        )
-      }
     }}
     id='license'
   >
@@ -111,8 +104,11 @@ const Licenses: React.FC<Props> = ({
     return (
       <DataLicense
         dataLicense={dataLicense}
-        setDataLicense={setDataLicense}
-        setLicense={setLicense}
+        setDataLicense={(value: string) => {
+          // Set preprint license to All Rights Reserved (not used in practice)
+          setLicense(6)
+          setDataLicense(value)
+        }}
       />
     )
   }

--- a/app/submit/(authed)/info/licenses.tsx
+++ b/app/submit/(authed)/info/licenses.tsx
@@ -93,6 +93,8 @@ const DataLicense = ({
     <option value={''}>Select one</option>
     <option value={'cc-by-4.0'}>CC BY 4.0</option>
     <option value={'cc-by-nc-4.0'}>CC BY-NC 4.0</option>
+    <option value={'cc-by-sa-4.0'}>CC BY-SA 4.0</option>
+    <option value={'cc-by-nc-sa-4.0'}>CC BY-NC-SA 4.0</option>
   </Select>
 )
 

--- a/app/submit/(authed)/overview/utils.ts
+++ b/app/submit/(authed)/overview/utils.ts
@@ -12,7 +12,6 @@ import {
   createDataDeposition,
 } from '../../../../actions'
 import { FileInputValue } from '../../../../components'
-import { LICENSE_MAPPING } from '../../constants'
 import {
   handleArticleUpload,
   handleDataUpload,
@@ -195,12 +194,11 @@ const getUpdatedFields = (
           (submissionType === 'Article' && field.field?.name === 'Data license')
         ) &&
         !(
-          // Remove 'Data license' for data-only submissions when it is out-of-sync with main license
+          // Remove 'Data license' for data-only submissions when the main license is anything other than 'All Rights Reserved'
           (
             submissionType === 'Data' &&
             field.field?.name === 'Data license' &&
-            LICENSE_MAPPING[field.answer as 'cc-by-4.0' | 'cc-by-nc-4.0'] !==
-              preprint.license?.pk
+            preprint.license?.pk !== 6
           )
         ),
     ),

--- a/app/submit/constants.ts
+++ b/app/submit/constants.ts
@@ -11,11 +11,6 @@ export const PATHS = [
   },
 ]
 
-export const LICENSE_MAPPING = {
-  'cc-by-4.0': 1,
-  'cc-by-nc-4.0': 4,
-}
-
 export const SUGGESTED_KEYWORD_MAPPING = {
   'Biological CDR': [
     'bioenergy with carbon capture and storage',

--- a/utils/data.ts
+++ b/utils/data.ts
@@ -101,16 +101,27 @@ const DATA_LICENSE_DISPLAY = {
     url: 'https://creativecommons.org/licenses/by/4.0/',
     name: 'CC BY 4.0',
   },
+  'cc-by-nc-sa-4.0': {
+    url: 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
+    name: 'CC BY-NC-SA 4.0',
+  },
+  'cc-by-sa-4.0': {
+    url: 'https://creativecommons.org/licenses/by-sa/4.0/',
+    name: 'CC BY-SA 4.0',
+  },
 }
 export const getZenodoLicense = (preprint: Preprint) => {
   const dataLicense = getAdditionalField(preprint, 'Data license')
     // Handle accidental capitalization (can occur in repository manager dashboard)
     ?.toLowerCase()
-  if (!dataLicense || !['cc-by-4.0', 'cc-by-nc-4.0'].includes(dataLicense)) {
+  if (
+    !dataLicense ||
+    DATA_LICENSE_DISPLAY[dataLicense as keyof typeof DATA_LICENSE_DISPLAY]
+  ) {
     return null
   }
 
-  return DATA_LICENSE_DISPLAY[dataLicense as 'cc-by-4.0' | 'cc-by-nc-4.0']
+  return DATA_LICENSE_DISPLAY[dataLicense as keyof typeof DATA_LICENSE_DISPLAY]
 }
 
 // Instead of relying on Janeway's license URLs, we override them here. This is because

--- a/utils/data.ts
+++ b/utils/data.ts
@@ -116,7 +116,7 @@ export const getZenodoLicense = (preprint: Preprint) => {
     ?.toLowerCase()
   if (
     !dataLicense ||
-    DATA_LICENSE_DISPLAY[dataLicense as keyof typeof DATA_LICENSE_DISPLAY]
+    !DATA_LICENSE_DISPLAY[dataLicense as keyof typeof DATA_LICENSE_DISPLAY]
   ) {
     return null
   }


### PR DESCRIPTION
This PR adds support for two new licenses for data submissions: `cc-by-sa-4.0` and `cc-by-nc-sa-4.0`. In order to support these, we are unwinding the requirement that data-only submissions store matching licenses on the Janeway preprint and Zenodo deposition. In those cases, the Janeway preprint is stored with `All Rights Reserved` license under the hood, though this is never used.