### PR TITLE
Update landing page to allow filtering by intersections of topics

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,22 @@
 import LandingPage from './landing-page'
 import PreprintsView from './preprints-view'
 import { fetchWithAlerting } from '../actions/server-utils'
-
 interface HomeProps {
-  searchParams: { [key: string]: string | undefined }
+  searchParams: { [key: string]: string | string[] | undefined }
 }
 
 const preprintsPerPage = 48
 
 const Home = async ({ searchParams }: HomeProps) => {
   const subject = searchParams.subject
-  const page = searchParams.page ? parseInt(searchParams.page) : 1
+  const page =
+    typeof searchParams.page === 'string' ? parseInt(searchParams.page) : 1
   const offset = (page - 1) * preprintsPerPage
   let url = `${process.env.NEXT_PUBLIC_JANEWAY_URL}/api/published_preprints/?limit=${preprintsPerPage}&offset=${offset}`
+
   if (subject) {
-    url += `&subject=${subject}`
+    const subjectArr = Array.isArray(subject) ? subject : [subject]
+    subjectArr.forEach((s) => (url += `&subject=${s}`))
   }
 
   let results = []

--- a/app/topics.tsx
+++ b/app/topics.tsx
@@ -4,19 +4,32 @@ import { Box, Flex } from 'theme-ui'
 import { Button, Column, Link, Menu, Row, Select } from '../components'
 import { useSubjects } from './subjects-context'
 
-const useTopicUrl = (topic: string) => {
+const useTopicUrl = (topic: string, multiSelect: boolean) => {
   const searchParams = useSearchParams()
+
   const params = new URLSearchParams(searchParams.toString())
   if (topic.startsWith('All')) {
     params.delete('subject')
-  } else {
+  } else if (multiSelect && searchParams.getAll('subject').includes(topic)) {
+    params.delete('subject', topic)
+  } else if (multiSelect) {
     params.append('subject', topic)
+  } else {
+    params.set('subject', topic)
   }
   return `/?${params.toString()}`
 }
 
-const Topic = ({ name, count }: { name: string; count: number }) => {
-  const topicUrl = useTopicUrl(name)
+const Topic = ({
+  name,
+  count,
+  multiSelect = true,
+}: {
+  name: string
+  count: number
+  multiSelect?: boolean
+}) => {
+  const topicUrl = useTopicUrl(name, multiSelect)
   const searchParams = useSearchParams()
   const selected = searchParams.get('subject')
     ? searchParams.getAll('subject').includes(name)
@@ -203,7 +216,7 @@ const Topics = () => {
               '@media (scripting: none)': { display: 'none' },
             }}
           >
-            {currentSubjects[0]}
+            {currentSubjects.length > 1 ? 'Multiple' : currentSubjects[0]}
           </Link>
 
           <noscript>
@@ -285,7 +298,7 @@ const Topics = () => {
             overflowY: 'auto',
           }}
         >
-          <Topic name='All' count={counts.total} />
+          <Topic name='All' count={counts.total} multiSelect={false} />
 
           <Box as='h3' sx={{ variant: 'text.mono' }}>
             Type
@@ -296,6 +309,7 @@ const Topics = () => {
               key={subject.name}
               name={subject.name}
               count={counts.subjects[subject.name]}
+              multiSelect={false}
             />
           ))}
 
@@ -308,6 +322,7 @@ const Topics = () => {
               key={subject.name}
               name={subject.name}
               count={counts.subjects[subject.name]}
+              multiSelect={false}
             />
           ))}
 
@@ -320,6 +335,7 @@ const Topics = () => {
               key={subject.name}
               name={subject.name}
               count={counts.subjects[subject.name]}
+              multiSelect={false}
             />
           ))}
         </Menu>

--- a/app/topics.tsx
+++ b/app/topics.tsx
@@ -42,6 +42,7 @@ const Topic = ({
       role='option'
       aria-selected={selected}
       aria-label={`${name} (${count} preprints)`}
+      disabled={multiSelect && count === 0}
       sx={{
         textDecoration: 'none',
         color: 'text',
@@ -57,7 +58,7 @@ const Topic = ({
         bg: selected ? 'highlight' : 'transparent',
         mb: '2px',
         ':hover': {
-          bg: 'highlight',
+          bg: count > 0 ? 'highlight' : 'none',
         },
       }}
     >

--- a/app/topics.tsx
+++ b/app/topics.tsx
@@ -69,13 +69,29 @@ const Topics = () => {
 
   const currentSubject = searchParams.get('subject') || 'All'
 
-  const totalCount = useMemo(() => {
+  const counts = useMemo(() => {
     const allPreprints = subjects.reduce((preprints, subject) => {
       subject.preprints.forEach((p) => preprints.add(p))
       return preprints
     }, new Set())
-    return allPreprints.size
-  }, [subjects])
+    const currentPreprints = new Set(
+      subjects.find((s) => s.name === currentSubject)?.preprints ??
+        allPreprints,
+    )
+
+    const bySubject = subjects.reduce<Record<string, number>>(
+      (accum, subject) => {
+        const subjectPreprints = new Set(subject.preprints)
+        accum[subject.name] =
+          currentPreprints.intersection(subjectPreprints).size
+
+        return accum
+      },
+      {},
+    )
+
+    return { total: allPreprints.size, subjects: bySubject }
+  }, [subjects, currentSubject])
 
   return (
     <Column start={[1, 1, 5, 5]} width={[3, 4, 8, 8]} sx={{ mb: [0, 0, 8, 8] }}>
@@ -101,7 +117,7 @@ const Topics = () => {
         aria-label='Topics'
       >
         <Column start={1} width={8} sx={{ pt: 1 }}>
-          <Topic name='All topics' count={totalCount} />
+          <Topic name='All topics' count={counts.total} />
         </Column>
 
         <Column start={1} width={4} sx={{ mt: 4 }}>
@@ -119,7 +135,7 @@ const Topics = () => {
               <Topic
                 key={subject.name}
                 name={subject.name}
-                count={subject.preprints.length}
+                count={counts.subjects[subject.name]}
               />
             ))}
 
@@ -131,7 +147,7 @@ const Topics = () => {
               <Topic
                 key={subject.name}
                 name={subject.name}
-                count={subject.preprints.length}
+                count={counts.subjects[subject.name]}
               />
             ))}
           </Flex>
@@ -146,7 +162,7 @@ const Topics = () => {
               <Topic
                 key={subject.name}
                 name={subject.name}
-                count={subject.preprints.length}
+                count={counts.subjects[subject.name]}
               />
             ))}
           </Flex>
@@ -196,21 +212,21 @@ const Topics = () => {
                   <optgroup label='Type'>
                     {buckets.type.map((subject) => (
                       <option key={subject.name} value={subject.name}>
-                        {subject.name} ({subject.preprints.length})
+                        {subject.name} ({counts.subjects[subject.name]})
                       </option>
                     ))}
                   </optgroup>
                   <optgroup label='Focus'>
                     {buckets.focus.map((subject) => (
                       <option key={subject.name} value={subject.name}>
-                        {subject.name} ({subject.preprints.length})
+                        {subject.name} ({counts.subjects[subject.name]})
                       </option>
                     ))}
                   </optgroup>
                   <optgroup label='Methdo'>
                     {buckets.focus.map((subject) => (
                       <option key={subject.name} value={subject.name}>
-                        {subject.name} ({subject.preprints.length})
+                        {subject.name} ({counts.subjects[subject.name]})
                       </option>
                     ))}
                   </optgroup>
@@ -252,7 +268,7 @@ const Topics = () => {
             overflowY: 'auto',
           }}
         >
-          <Topic name='All' count={totalCount} />
+          <Topic name='All' count={counts.total} />
 
           <Box as='h3' sx={{ variant: 'text.mono' }}>
             Type
@@ -262,7 +278,7 @@ const Topics = () => {
             <Topic
               key={subject.name}
               name={subject.name}
-              count={subject.preprints.length}
+              count={counts.subjects[subject.name]}
             />
           ))}
 
@@ -274,7 +290,7 @@ const Topics = () => {
             <Topic
               key={subject.name}
               name={subject.name}
-              count={subject.preprints.length}
+              count={counts.subjects[subject.name]}
             />
           ))}
 
@@ -286,7 +302,7 @@ const Topics = () => {
             <Topic
               key={subject.name}
               name={subject.name}
-              count={subject.preprints.length}
+              count={counts.subjects[subject.name]}
             />
           ))}
         </Menu>

--- a/app/topics.tsx
+++ b/app/topics.tsx
@@ -240,7 +240,7 @@ const Topics = () => {
                       </option>
                     ))}
                   </optgroup>
-                  <optgroup label='Methdo'>
+                  <optgroup label='Method'>
                     {buckets.focus.map((subject) => (
                       <option key={subject.name} value={subject.name}>
                         {subject.name} ({counts.subjects[subject.name]})


### PR DESCRIPTION
- Leaves behavior the same for mobile (JS-enabled and -disabled)
- Because `Set.prototype.intersection()` [only got Node support in v22](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/intersection#browser_compatibility), I also updated to v22 in Vercel (in order to support server rendering when JS is disabled)