### PR TITLE
Avoid using Set.prototype.intersection for older browser support

### DIFF
--- a/app/topics.tsx
+++ b/app/topics.tsx
@@ -75,6 +75,17 @@ const Topic = ({
   )
 }
 
+const getIntersection = (setA: Set<string>, setB: Set<string>) => {
+  const result = new Set<string>()
+  setA.forEach((value) => {
+    if (setB.has(value)) {
+      result.add(value)
+    }
+  })
+
+  return result
+}
+
 const Topics = () => {
   const searchParams = useSearchParams()
   const { subjects, buckets } = useSubjects()
@@ -103,7 +114,7 @@ const Topics = () => {
         )?.preprints
 
         return activePreprints
-          ? preprints.intersection(new Set(activePreprints))
+          ? getIntersection(preprints, new Set(activePreprints))
           : preprints
       },
       new Set(allPreprints),
@@ -112,8 +123,10 @@ const Topics = () => {
     const bySubject = subjects.reduce<Record<string, number>>(
       (accum, subject) => {
         const subjectPreprints = new Set(subject.preprints)
-        accum[subject.name] =
-          currentPreprints.intersection(subjectPreprints).size
+        accum[subject.name] = getIntersection(
+          currentPreprints,
+          subjectPreprints,
+        ).size
 
         return accum
       },


### PR DESCRIPTION
This PR updates landing page logic to use older `Set` methods to enable support for client-side filtering for older browsers (e.g., Safari 16).