### PR TITLE
Clone response for logging purposes

### DIFF
--- a/actions/server-utils.ts
+++ b/actions/server-utils.ts
@@ -92,7 +92,7 @@ export const fetchWithAlerting = async (
   if (!expectedStatuses.includes(response.status)) {
     let apiError
     try {
-      const data = await response.json()
+      const data = await response.clone().json()
       apiError = JSON.stringify(data)
     } catch {
       console.warn('Unable to extract error message from response')


### PR DESCRIPTION
## Background
When we `fetchWithAlerting()` and hit an error, we use `.json()` to inspect the response body and alert to Slack with the response details. This leads to downstream `TypeError`s on subsequent use of the response body, such as in the [error parsing in `registerAccount`](https://github.com/cdrxiv/cdrxiv.org/blob/815e4a86fb1402e7ab799670b3de95bf156b342e/actions/account.ts#L26). 

## Fix
Use [Response `.clone()` method](https://developer.mozilla.org/en-US/docs/Web/API/Response/clone), which allows for multiple uses of body objects. We use within `fetchWithAlerting()` both to standardize its usage, but also because `.clone()` can only be called on unused response bodies.

cc @Shane98c 