### PR TITLE
Serve PDF worker locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # production
 /build
+/public/pdf.worker.min.mjs
 
 # misc
 .DS_Store

--- a/app/preprint/[id]/preprint-viewer.tsx
+++ b/app/preprint/[id]/preprint-viewer.tsx
@@ -23,7 +23,7 @@ import { fetchDataDeposition, fetchPreprintIdentifier } from '../../../actions'
 import ErrorOrTrack from './error-or-track'
 import { alertOnError } from '../../../actions/server-utils'
 
-pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`
+pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.mjs'
 
 const PreprintViewer = ({
   preprint,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "prepare:pdf-worker": "node scripts/copy-pdf-worker.mjs",
+    "predev": "npm run prepare:pdf-worker",
     "dev": "next dev",
+    "prebuild": "npm run prepare:pdf-worker",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/scripts/copy-pdf-worker.mjs
+++ b/scripts/copy-pdf-worker.mjs
@@ -1,0 +1,11 @@
+import { copyFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const pdfjsDirectory = dirname(require.resolve('pdfjs-dist/package.json'))
+
+copyFileSync(
+  join(pdfjsDirectory, 'build/pdf.worker.min.mjs'),
+  join(process.cwd(), 'public/pdf.worker.min.mjs'),
+)


### PR DESCRIPTION
Saw a couple intermittent errors about failing to fetch from unpkg, so wiring up local hosting of our pdf viewer's worker here to avoid the external dependency. 